### PR TITLE
hot-fix regarding redirection url to handle edge cases & change redirect icon to text

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -223,17 +223,13 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
               url={canExplore ? exploreUrl : undefined}
             />
           </Tooltip>
-          {sliceName?.split(",").length > 1 && (
+            {sliceName?.split(",").length > 1 && sliceName.split(",")[1]?.trim() && (
             <a href={sliceName.split(",")[1]} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>
               <span style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center' }}>
-                <img
-                  src={redirectIcon}
-                  alt="Redirect"
-                  style={{ width: '24px', height: '24px' }}
-                />
-              </span>
+                Drilldown
+                </span>
             </a>
-          )}
+            )}
           {!!Object.values(annotationQuery).length && (
             <Tooltip
               id="annotations-loading-tooltip"


### PR DESCRIPTION

This PR fix the bug related to redirection URL
Earlier - 
1. when user removes redirection url, redirection icon remains on the chart in dashboard
2. Ajna icon for redirection url
Now - 
1. If the redirection url is removed, redirection icon also disappears
2. "Drilldown" text for redirection url 
[Screencast from 2025-02-04 00-07-04.webm](https://github.com/user-attachments/assets/fdbdee57-db56-4f6b-9623-70018f1475a4)
